### PR TITLE
RainRust 光照: 修复 alpha 语义不一致 + Debug 可视化

### DIFF
--- a/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02.unity
+++ b/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e3e31fe73fdadfaa5567c4b5c55c86b66fabacbbf5dcc4e4107b52e0e5346c9
-size 16096
+oid sha256:58d1783b9e0bbca6c9c8bbde2a42ebfd60ee31a4793fe8b91a2957df2abf0577
+size 16095

--- a/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02.unity
+++ b/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03c0a6876a0350c8747cba4d92232f4e8205afedd502f6bab2c01dab7bfe6bb1
-size 16094
+oid sha256:58d1783b9e0bbca6c9c8bbde2a42ebfd60ee31a4793fe8b91a2957df2abf0577
+size 16095

--- a/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02.unity
+++ b/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58d1783b9e0bbca6c9c8bbde2a42ebfd60ee31a4793fe8b91a2957df2abf0577
-size 16095
+oid sha256:8e3e31fe73fdadfaa5567c4b5c55c86b66fabacbbf5dcc4e4107b52e0e5346c9
+size 16096

--- a/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02/volum Profile.asset
+++ b/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02/volum Profile.asset
@@ -61,7 +61,7 @@ MonoBehaviour:
     m_Value: {r: 0, g: 0, b: 0, a: 1}
   debugMode:
     m_OverrideState: 1
-    m_Value: 9
+    m_Value: 0
   debugPixelUV:
     m_OverrideState: 1
     m_Value: {x: 0.5943, y: 0.4139}

--- a/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02/volum Profile.asset
+++ b/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02/volum Profile.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
     m_Value: 1
   lightSamples:
     m_OverrideState: 1
-    m_Value: 32
+    m_Value: 8
   lightIntensity:
     m_OverrideState: 1
     m_Value: 8.28
@@ -60,11 +60,11 @@ MonoBehaviour:
     m_OverrideState: 1
     m_Value: {r: 0, g: 0, b: 0, a: 1}
   debugMode:
-    m_OverrideState: 0
-    m_Value: 8
+    m_OverrideState: 1
+    m_Value: 9
   debugPixelUV:
     m_OverrideState: 1
-    m_Value: {x: 0.5, y: 0.5}
+    m_Value: {x: 0.5943, y: 0.4139}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02/volum Profile.asset
+++ b/Assets/Demos/RainRustRenderPipelineDemo/DemoScene_02/volum Profile.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     m_Value: 2
   noiseType:
     m_OverrideState: 1
-    m_Value: 1
+    m_Value: 2
   alphaMode:
     m_OverrideState: 1
     m_Value: 0
@@ -31,22 +31,22 @@ MonoBehaviour:
     dimension: 1
   noiseTilingOffset:
     m_OverrideState: 1
-    m_Value: {x: 1, y: 1, z: 1, w: 1}
+    m_Value: {x: 0, y: 0, z: 0, w: 0}
   noiseVelocity:
     m_OverrideState: 1
-    m_Value: {x: 1, y: 1}
+    m_Value: {x: 0, y: 0}
   noiseScale:
     m_OverrideState: 1
-    m_Value: 10
+    m_Value: 1
   noiseIntensity:
     m_OverrideState: 1
-    m_Value: 3.08
+    m_Value: 10
   resolutionScalar:
     m_OverrideState: 1
     m_Value: 1
   lightSamples:
     m_OverrideState: 1
-    m_Value: 16
+    m_Value: 32
   lightIntensity:
     m_OverrideState: 1
     m_Value: 8.28
@@ -59,6 +59,12 @@ MonoBehaviour:
   ambientColor:
     m_OverrideState: 1
     m_Value: {r: 0, g: 0, b: 0, a: 1}
+  debugMode:
+    m_OverrideState: 0
+    m_Value: 8
+  debugPixelUV:
+    m_OverrideState: 1
+    m_Value: {x: 0.5, y: 0.5}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/GameMain/Rendering/Settings/urp_rendererData_2d_default.asset
+++ b/Assets/GameMain/Rendering/Settings/urp_rendererData_2d_default.asset
@@ -107,6 +107,7 @@ MonoBehaviour:
     jfaInitShader: {fileID: 4800000, guid: dd31d820cbe84594ab44e95677803384, type: 3}
     jfaShader: {fileID: 4800000, guid: 8eca780a8019b4342aaae937ef5ea113, type: 3}
     distanceShader: {fileID: 4800000, guid: e5b5c2dcbb8666748a8787686a9c2b44, type: 3}
+    unpremultiplyShader: {fileID: 4800000, guid: 529b71fe6af22c2448df2d9f0ed024d4, type: 3}
     rayTracingShader: {fileID: 4800000, guid: 86ce958f21ce23d4a8bb8b0d38411f75, type: 3}
     compositionShader: {fileID: 4800000, guid: a61490a2ecb36094599f34a4839eed3b, type: 3}
     blitShader: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}

--- a/Assets/GameMain/Rendering/Settings/urp_rendererData_default.asset
+++ b/Assets/GameMain/Rendering/Settings/urp_rendererData_default.asset
@@ -26,6 +26,7 @@ MonoBehaviour:
     jfaInitShader: {fileID: 4800000, guid: dd31d820cbe84594ab44e95677803384, type: 3}
     jfaShader: {fileID: 4800000, guid: 8eca780a8019b4342aaae937ef5ea113, type: 3}
     distanceShader: {fileID: 4800000, guid: e5b5c2dcbb8666748a8787686a9c2b44, type: 3}
+    unpremultiplyShader: {fileID: 4800000, guid: 529b71fe6af22c2448df2d9f0ed024d4, type: 3}
     rayTracingShader: {fileID: 4800000, guid: 86ce958f21ce23d4a8bb8b0d38411f75, type: 3}
     compositionShader: {fileID: 4800000, guid: a61490a2ecb36094599f34a4839eed3b, type: 3}
     blitShader: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}

--- a/Assets/Rendering/RainRust/Materials/Crt.mat
+++ b/Assets/Rendering/RainRust/Materials/Crt.mat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c65e655754ffecfc578f1c9ae4ec83f62b560bcda9da7060cb2c581537fd9693
-size 3886
+oid sha256:d602322e7e21a62ac6355ca1630c03dd26536855784a68263bf8d0be3fedf45d
+size 3876

--- a/Assets/Rendering/RainRust/RenderFeatures/RainRustLighting.cs
+++ b/Assets/Rendering/RainRust/RenderFeatures/RainRustLighting.cs
@@ -31,12 +31,13 @@ namespace RainRust.Rendering
             public BlendMode lightingBlendMode = BlendMode.Additive;
 
             [Header("Shaders")]
-            public Shader jfaInitShader     ;
-            public Shader jfaShader         ;
-            public Shader distanceShader    ;
-            public Shader rayTracingShader  ;
-            public Shader compositionShader ;
-            public Shader blitShader        ;
+            public Shader jfaInitShader       ;
+            public Shader jfaShader           ;
+            public Shader distanceShader      ;
+            public Shader unpremultiplyShader ;
+            public Shader rayTracingShader    ;
+            public Shader compositionShader   ;
+            public Shader blitShader          ;
             // csharpier-ignore-end
         }
 
@@ -49,6 +50,7 @@ namespace RainRust.Rendering
         {
             // csharpier-ignore-start
             m_RainRustDrawObjectsPass = new RainRustDrawObjectsPass(); // 绘制所有光源, 用于后续光场计算
+            m_UnpremultiplyPass       = new RainRustUnpremultiplyPass(); // 把 mainRt 从 premultiplied 转为 straight alpha
             m_JfaInitPass             = new RainRustJfaInitPass(); // 从光源数据获得JFA初始种子
             m_JfaPass                 = new RainRustJfaPass(); // Jump Flood Algorithm
             m_DistancePass            = new RainRustDistancePass(); // JFA -> Distance Field
@@ -81,6 +83,8 @@ namespace RainRust.Rendering
                 CLogger.LogError("[RainRust] JFA Shader is MISSING!", LogTag.Rendering);
             if (settings.distanceShader == null)
                 CLogger.LogError("[RainRust] Distance Shader is MISSING!", LogTag.Rendering);
+            if (settings.unpremultiplyShader == null)
+                CLogger.LogError("[RainRust] Unpremultiply Shader is MISSING!", LogTag.Rendering);
             if (settings.rayTracingShader == null)
                 CLogger.LogError("[RainRust] RayTracing Shader is MISSING!", LogTag.Rendering);
             if (settings.compositionShader == null)
@@ -90,6 +94,7 @@ namespace RainRust.Rendering
             // csharpier-ignore-start
             // Apply settings to all passes
             m_RainRustDrawObjectsPass.renderPassEvent = settings.injectionPoint;
+            m_UnpremultiplyPass.renderPassEvent       = settings.injectionPoint;
             m_JfaInitPass.renderPassEvent             = settings.injectionPoint;
             m_JfaPass.renderPassEvent                 = settings.injectionPoint;
             m_DistancePass.renderPassEvent            = settings.injectionPoint;
@@ -97,6 +102,7 @@ namespace RainRust.Rendering
             m_RainRustRenderingPass.renderPassEvent   = settings.injectionPoint;
 
             m_RainRustDrawObjectsPass.Setup(settings);
+            m_UnpremultiplyPass      .Setup(settings);
             m_JfaInitPass            .Setup(settings);
             m_JfaPass                .Setup(settings);
             m_DistancePass           .Setup(settings);
@@ -105,6 +111,7 @@ namespace RainRust.Rendering
             // csharpier-ignore-end
 
             renderer.EnqueuePass(m_RainRustDrawObjectsPass);
+            renderer.EnqueuePass(m_UnpremultiplyPass);
             renderer.EnqueuePass(m_JfaInitPass);
             renderer.EnqueuePass(m_JfaPass);
             renderer.EnqueuePass(m_DistancePass);
@@ -117,6 +124,7 @@ namespace RainRust.Rendering
             base.Dispose(disposing);
             m_JfaInitPass?.Dispose();
             m_JfaPass?.Dispose();
+            m_UnpremultiplyPass?.Dispose();
             m_RainRustRenderingPass?.Dispose();
         }
 
@@ -134,6 +142,8 @@ namespace RainRust.Rendering
                 settings.jfaShader = Shader.Find("Hidden/RainRust/JumpFloodAlgorithm");
             if (settings.distanceShader == null)
                 settings.distanceShader = Shader.Find("Hidden/RainRust/Distance");
+            if (settings.unpremultiplyShader == null)
+                settings.unpremultiplyShader = Shader.Find("Hidden/RainRust/Unpremultiply");
             if (settings.rayTracingShader == null)
                 settings.rayTracingShader = Shader.Find("Hidden/RainRust/RayTracing");
             if (settings.compositionShader == null)
@@ -144,12 +154,13 @@ namespace RainRust.Rendering
 
         // csharpier-ignore-start
 
-        private RainRustDrawObjectsPass m_RainRustDrawObjectsPass;
-        private RainRustJfaInitPass     m_JfaInitPass;
-        private RainRustJfaPass         m_JfaPass;
-        private RainRustDistancePass    m_DistancePass;
-        private RainRustRayTracingPass  m_RainRustRayTracingPass;
-        private RainRustRenderingPass   m_RainRustRenderingPass;
+        private RainRustDrawObjectsPass   m_RainRustDrawObjectsPass;
+        private RainRustUnpremultiplyPass m_UnpremultiplyPass;
+        private RainRustJfaInitPass       m_JfaInitPass;
+        private RainRustJfaPass           m_JfaPass;
+        private RainRustDistancePass      m_DistancePass;
+        private RainRustRayTracingPass    m_RainRustRayTracingPass;
+        private RainRustRenderingPass     m_RainRustRenderingPass;
         // csharpier-ignore-end
     }
 }

--- a/Assets/Rendering/RainRust/RenderPasses/RainRustRayTracingPass.cs
+++ b/Assets/Rendering/RainRust/RenderPasses/RainRustRayTracingPass.cs
@@ -161,6 +161,46 @@ namespace RainRust.Rendering
                                 break;
                         }
 
+                        // Debug keyword 一律先清空, 再按当前 debugMode 启用
+                        data.material.DisableKeyword("DEBUG_RAND");
+                        data.material.DisableKeyword("DEBUG_SAMPLEDIR");
+                        data.material.DisableKeyword("DEBUG_COLORALPHA");
+                        data.material.DisableKeyword("DEBUG_EARLYEXIT");
+                        data.material.DisableKeyword("DEBUG_RAYTERMSTEP");
+                        data.material.DisableKeyword("DEBUG_HITFRACTION");
+                        data.material.DisableKeyword("DEBUG_SDF");
+                        data.material.DisableKeyword("DEBUG_PIXELINSPECTOR");
+                        switch (stack.debugMode.value)
+                        {
+                            case RainRustDebugMode.None:
+                                break;
+                            case RainRustDebugMode.Rand:
+                                data.material.EnableKeyword("DEBUG_RAND");
+                                break;
+                            case RainRustDebugMode.SampleDir:
+                                data.material.EnableKeyword("DEBUG_SAMPLEDIR");
+                                break;
+                            case RainRustDebugMode.ColorAlpha:
+                                data.material.EnableKeyword("DEBUG_COLORALPHA");
+                                break;
+                            case RainRustDebugMode.EarlyExit:
+                                data.material.EnableKeyword("DEBUG_EARLYEXIT");
+                                break;
+                            case RainRustDebugMode.RayTermStep:
+                                data.material.EnableKeyword("DEBUG_RAYTERMSTEP");
+                                break;
+                            case RainRustDebugMode.HitFraction:
+                                data.material.EnableKeyword("DEBUG_HITFRACTION");
+                                break;
+                            case RainRustDebugMode.Sdf:
+                                data.material.EnableKeyword("DEBUG_SDF");
+                                break;
+                            case RainRustDebugMode.PixelInspector:
+                                data.material.EnableKeyword("DEBUG_PIXELINSPECTOR");
+                                data.material.SetVector("_DebugPixelUV", stack.debugPixelUV.value);
+                                break;
+                        }
+
                         CoreUtils.DrawFullScreen(cmd, data.material);
                     }
                 );

--- a/Assets/Rendering/RainRust/RenderPasses/RainRustRayTracingPass.cs
+++ b/Assets/Rendering/RainRust/RenderPasses/RainRustRayTracingPass.cs
@@ -97,6 +97,7 @@ namespace RainRust.Rendering
                         data.material.SetFloat("_Intensity", stack.lightIntensity.value);
                         data.material.SetFloat("_LightFalloffAlpha", stack.lightFalloffAlpha.value);
                         data.material.SetFloat("_LightFalloffGamma", stack.lightFalloffGamma.value);
+                        data.material.SetFloat("_LightHitThreshold", stack.lightHitThreshold.value);
                         data.material.SetColor("_AmbientColor", stack.ambientColor.value);
 
                         data.material.SetFloat("_NoiseScale", stack.noiseScale.value);

--- a/Assets/Rendering/RainRust/RenderPasses/RainRustRayTracingPass.cs
+++ b/Assets/Rendering/RainRust/RenderPasses/RainRustRayTracingPass.cs
@@ -170,6 +170,7 @@ namespace RainRust.Rendering
                         data.material.DisableKeyword("DEBUG_HITFRACTION");
                         data.material.DisableKeyword("DEBUG_SDF");
                         data.material.DisableKeyword("DEBUG_PIXELINSPECTOR");
+                        data.material.DisableKeyword("DEBUG_GTRBREAKDOWN");
                         switch (stack.debugMode.value)
                         {
                             case RainRustDebugMode.None:
@@ -197,6 +198,10 @@ namespace RainRust.Rendering
                                 break;
                             case RainRustDebugMode.PixelInspector:
                                 data.material.EnableKeyword("DEBUG_PIXELINSPECTOR");
+                                data.material.SetVector("_DebugPixelUV", stack.debugPixelUV.value);
+                                break;
+                            case RainRustDebugMode.GTRBreakdown:
+                                data.material.EnableKeyword("DEBUG_GTRBREAKDOWN");
                                 data.material.SetVector("_DebugPixelUV", stack.debugPixelUV.value);
                                 break;
                         }

--- a/Assets/Rendering/RainRust/RenderPasses/RainRustRenderingPass.cs
+++ b/Assets/Rendering/RainRust/RenderPasses/RainRustRenderingPass.cs
@@ -117,6 +117,13 @@ namespace RainRust.Rendering
                         data.material.SetTexture("_ReceiverTex", data.receiverRt);
                         data.material.SetTexture("_ReceiverDepthTex", data.receiverDepthRt);
 
+                        // Debug override: 在任一 RT debug 模式下, 让 composition 直接输出 lightingRt
+                        var debugStack = VolumeManager.instance.stack.GetComponent<RainRustVolume>();
+                        if (debugStack != null && debugStack.debugMode.value != RainRustDebugMode.None)
+                            data.material.EnableKeyword("RAINRUST_DEBUG_OVERRIDE");
+                        else
+                            data.material.DisableKeyword("RAINRUST_DEBUG_OVERRIDE");
+
                         // Clear keywords
                         data.material.DisableKeyword("RECEIVER_BLEND_ADDITIVE");
                         data.material.DisableKeyword("RECEIVER_BLEND_ALPHABLEND");

--- a/Assets/Rendering/RainRust/RenderPasses/RainRustUnpremultiplyPass.cs
+++ b/Assets/Rendering/RainRust/RenderPasses/RainRustUnpremultiplyPass.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.RenderGraphModule;
+using UnityEngine.Rendering.RenderGraphModule.Util;
+using UnityEngine.Rendering.Universal;
+
+namespace RainRust.Rendering
+{
+    public class RainRustUnpremultiplyPass : ScriptableRenderPass
+    {
+        public RainRustUnpremultiplyPass()
+        {
+            renderPassEvent = RenderPassEvent.BeforeRenderingOpaques;
+        }
+
+        public void Setup(RainRustLighting.RainRustLightingSettings settings)
+        {
+            m_Settings = settings;
+        }
+
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            var rainRustData = frameData.Get<RainRustContextData>();
+            if (rainRustData == null || m_Settings == null)
+                return;
+
+            if (m_UnpremultiplyMaterial == null && m_Settings.unpremultiplyShader != null)
+            {
+                m_UnpremultiplyMaterial = CoreUtils.CreateEngineMaterial(
+                    m_Settings.unpremultiplyShader
+                );
+            }
+
+            if (m_UnpremultiplyMaterial == null)
+                return;
+
+            if (!rainRustData.mainRt.IsValid())
+                return;
+
+            var desc = renderGraph.GetTextureDesc(rainRustData.mainRt);
+            desc.name = "RainRust Main Texture (Straight Alpha)";
+            desc.clearBuffer = true;
+
+            TextureHandle straightRt = renderGraph.CreateTexture(desc);
+
+            renderGraph.AddBlitPass(
+                new RenderGraphUtils.BlitMaterialParameters(
+                    rainRustData.mainRt,
+                    straightRt,
+                    m_UnpremultiplyMaterial,
+                    0
+                ),
+                "RainRust Unpremultiply"
+            );
+
+            rainRustData.mainRt = straightRt;
+        }
+
+        public void Dispose()
+        {
+            CoreUtils.Destroy(m_UnpremultiplyMaterial);
+        }
+
+        private Material m_UnpremultiplyMaterial;
+        private RainRustLighting.RainRustLightingSettings m_Settings;
+    }
+}

--- a/Assets/Rendering/RainRust/RenderPasses/RainRustUnpremultiplyPass.cs.meta
+++ b/Assets/Rendering/RainRust/RenderPasses/RainRustUnpremultiplyPass.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3bd9f0b9dc28c2e4b95af941d2ecabaa

--- a/Assets/Rendering/RainRust/Shaders/JfaSeedInit.shader
+++ b/Assets/Rendering/RainRust/Shaders/JfaSeedInit.shader
@@ -58,7 +58,7 @@ Shader "Hidden/RainRust/JfaSeedInit"
                 float alpha = SAMPLE_TEXTURE2D(_BlitTexture, sampler_BlitTexture, i.uv).a;
 
                 // 使用 Z 通道作为种子有效性标记 (1.0 表示是种子, 0.0 表示不是)
-                if (alpha > 0.001)
+                if (alpha > 0)
                 {
                     return float4(i.uv, 1, 1);
                 }

--- a/Assets/Rendering/RainRust/Shaders/RainRustComposition.shader
+++ b/Assets/Rendering/RainRust/Shaders/RainRustComposition.shader
@@ -24,6 +24,7 @@ Shader "Hidden/RainRust/Composition"
             #pragma fragment frag
             #pragma multi_compile _ RECEIVER_BLEND_ADDITIVE RECEIVER_BLEND_ALPHABLEND RECEIVER_BLEND_MULTIPLY RECEIVER_BLEND_SCREEN RECEIVER_BLEND_OVERLAY
             #pragma multi_compile _ LIGHTING_BLEND_ADDITIVE LIGHTING_BLEND_ALPHABLEND LIGHTING_BLEND_MULTIPLY LIGHTING_BLEND_SCREEN LIGHTING_BLEND_OVERLAY
+            #pragma multi_compile _ RAINRUST_DEBUG_OVERRIDE
             
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
@@ -59,6 +60,12 @@ Shader "Hidden/RainRust/Composition"
             {
                 float4 background = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
                 float4 lighting = SAMPLE_TEXTURE2D(_LightingTex, sampler_LightingTex, input.uv);
+
+                // Debug 模式: 直接显示 RT (绕过 receiver mask 和 blend mode)
+                #if defined(RAINRUST_DEBUG_OVERRIDE)
+                return float4(lighting.rgb, 1);
+                #endif
+
                 float4 receiver = SAMPLE_TEXTURE2D(_ReceiverTex, sampler_ReceiverTex, input.uv);
                 float depth = SAMPLE_TEXTURE2D(_ReceiverDepthTex, sampler_ReceiverDepthTex, input.uv).r;
 

--- a/Assets/Rendering/RainRust/Shaders/RayTracing.shader
+++ b/Assets/Rendering/RainRust/Shaders/RayTracing.shader
@@ -33,19 +33,23 @@ Shader "Hidden/RainRust/RayTracing"
             #pragma vertex Vert
             #pragma fragment Frag
 
-            TEXTURE2D(_ColorTex); // 场景颜色纹理
+            // _ColorTex 语义: straight alpha (Unpremultiply pass 之后)
+            //   rgb = lightColor (不被 alpha 加权污染)
+            //   a   = 覆盖率/不透明度 mask
+            TEXTURE2D(_ColorTex);
             SAMPLER(sampler_ColorTex);   // 跟随纹理 import filter (bilinear)
-            // sampler_PointClamp 由 URP Core.hlsl 提供; 仅用于 GTR 的 cn.a 输入, 避免次像素 bilinear 抖动
+            // sampler_PointClamp 由 URP Core.hlsl 提供, 用于 GTRBreakdown 诊断
             sampler2D _DistTex; // 场景距离纹理 (SDF)
             sampler2D _NoiseTex; // 随机噪声纹理
 
             float2 _Aspect; // 16:9 为 (1, 0.5625)
             float4 _NoiseTilingOffset; // 噪声纹理的缩放和偏移 (tiling.x, tiling.y, offset.x, offset.y)
-            
+
             float  _Samples; // 光线采样数
             float _Intensity; // 光照强度
             float _LightFalloffAlpha; // GTR 衰减 alpha 参数
             float _LightFalloffGamma; // GTR 衰减 gamma 参数
+            float _LightHitThreshold; // 命中判定: cn.a > 阈值 视为命中光源 (TODO(vanish): RainRustLighting.shader 中clip 阈值是Hard Code)
             float3 _AmbientColor; // 环境光颜色
 
             // 噪声相关参数
@@ -80,23 +84,22 @@ Shader "Hidden/RainRust/RayTracing"
             {
                 float2 uvPos = uv; // 当前采样坐标
 
-                // 若起始点已在光源上, 直接返回颜色
-                const float4 color = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uv).rgba;
-                if (color.a > 0)
-                    return color.rgb / color.a;
-                
+                // 若起始点已在光源上, 直接返回光源色
+                const float4 color = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uv).rgba;
+                if (color.a > _LightHitThreshold)
+                    return color.rgb;
+
                 // 步进
                 uvPos += dir * tex2D(_DistTex, uvPos).rr;
                 if (NotUVSpace(uvPos))
                     return _AmbientColor;
-                
+
                 [unroll]
                 for (int n = 1; n < STEPS; n++)
                 {
                     const float4 color = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvPos).rgba;
-                    if (color.a > 0)
+                    if (color.a > _LightHitThreshold)
                     {
-                        // GTR 衰减
                         float attenuation = GTRAttenuation((uv - uvPos) * _Aspect.xy, _LightFalloffAlpha, _LightFalloffGamma);
                         return color.rgb * attenuation;
                     }
@@ -185,8 +188,8 @@ Shader "Hidden/RainRust/RayTracing"
 #elif defined(DEBUG_EARLYEXIT)
                 // H2: 红色 = 走 early-exit 直接返回光源色; 暗绿 = 走 ray marching 路径
                 {
-                    const float ea = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,i.uv).a;
-                    return (ea > 0) ? float4(1, 0, 0, 1) : float4(0, 0.25, 0, 1);
+                    const float ea = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, i.uv).a;
+                    return (ea > _LightHitThreshold) ? float4(1, 0, 0, 1) : float4(0, 0.25, 0, 1);
                 }
 
 #elif defined(DEBUG_SDF)
@@ -201,8 +204,8 @@ Shader "Hidden/RainRust/RayTracing"
                 //   - X 方向: ray 编号 0 .. _Samples-1
                 //   - Y 方向: 9 个条带 (从 Y=0 即屏幕顶端往下):
                 //       0: hit/miss (1/0)
-                //       1: 命中光源原色 (cn.rgb / cn.a, 无衰减; miss 显黑)
-                //       2: contribution RGB  (color*atten | color/alpha | _AmbientColor)
+                //       1: 命中光源原色 cn.rgb (straight alpha 下直接 = lightColor; miss 显黑)
+                //       2: contribution RGB  (color*atten | color | _AmbientColor)
                 //       3: share = length(thisContrib) / sum_k length(contrib_k)
                 //       4: used / STEPS
                 //       5: GTR attenuation
@@ -262,15 +265,15 @@ Shader "Hidden/RainRust/RayTracing"
                         float2 hitUVR     = float2(0, 0);
                         float  hasHitUVR  = 0;
 
-                        const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uvP).rgba;
-                        if (c0.a > 0)
+                        const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
+                        if (c0.a > _LightHitThreshold)
                         {
                             // 起点就在光源上 (原 Trace 的 early-exit 路径)
                             usedR     = 0;
                             hitR      = 1;
                             attenR    = 1;
-                            contribR  = c0.rgb / c0.a;
-                            lightColR = c0.rgb / c0.a;
+                            contribR  = c0.rgb;
+                            lightColR = c0.rgb;
                             hitUVR    = uvP;
                             hasHitUVR = 1;
                         }
@@ -288,7 +291,7 @@ Shader "Hidden/RainRust/RayTracing"
                                 for (int n = 1; n < STEPS; n++)
                                 {
                                     const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
-                                    if (cn.a > 0)
+                                    if (cn.a > _LightHitThreshold)
                                     {
                                         usedR     = n;
                                         hitR      = 1;
@@ -298,7 +301,7 @@ Shader "Hidden/RainRust/RayTracing"
                                             _LightFalloffGamma
                                         );
                                         contribR  = cn.rgb * attenR;
-                                        lightColR = cn.rgb / cn.a;
+                                        lightColR = cn.rgb;
                                         hitUVR    = uvP;
                                         hasHitUVR = 1;
                                         break;
@@ -404,7 +407,7 @@ Shader "Hidden/RainRust/RayTracing"
 
                     // 注意: hit 判定仍走 bilinear (与正常渲染一致), 但 hitA 用 point 采样
                     const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
-                    if (c0.a > 0)
+                    if (c0.a > _LightHitThreshold)
                     {
                         hitR  = 1;
                         hitA  = SAMPLE_TEXTURE2D(_ColorTex, sampler_PointClamp, uvP).a;
@@ -419,7 +422,7 @@ Shader "Hidden/RainRust/RayTracing"
                             for (int n = 1; n < STEPS; n++)
                             {
                                 const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
-                                if (cn.a > 0)
+                                if (cn.a > _LightHitThreshold)
                                 {
                                     hitR  = 1;
                                     hitA  = SAMPLE_TEXTURE2D(_ColorTex, sampler_PointClamp, uvP).a;
@@ -472,8 +475,8 @@ Shader "Hidden/RainRust/RayTracing"
                         float used = STEPS;
                         float didHit = 0;
 
-                        const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uvPos).rgba;
-                        if (c0.a > 0)
+                        const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvPos).rgba;
+                        if (c0.a > _LightHitThreshold)
                         {
                             used = 0;
                             didHit = 1;
@@ -485,8 +488,8 @@ Shader "Hidden/RainRust/RayTracing"
                             {
                                 uvPos += dir * tex2D(_DistTex, uvPos).rr;
                                 if (NotUVSpace(uvPos)) { used = n; break; }
-                                const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uvPos).rgba;
-                                if (cn.a > 0) { used = n; didHit = 1; break; }
+                                const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvPos).rgba;
+                                if (cn.a > _LightHitThreshold) { used = n; didHit = 1; break; }
                             }
                         }
 

--- a/Assets/Rendering/RainRust/Shaders/RayTracing.shader
+++ b/Assets/Rendering/RainRust/Shaders/RayTracing.shader
@@ -27,6 +27,8 @@ Shader "Hidden/RainRust/RayTracing"
             #pragma multi_compile_local FRAGMENT_RANDOM TEXTURE_RANDOM _
             // 输出alpha通道方式: 全部为1, 使用对象遮罩, 颜色归一化后最大值
             #pragma multi_compile_local ONE_ALPHA OBJECTS_MASK_ALPHA NORMALIZED_ALPHA
+            // Debug 可视化模式 (_ 表示关闭, 即正常渲染)
+            #pragma multi_compile_local _ DEBUG_RAND DEBUG_SAMPLEDIR DEBUG_COLORALPHA DEBUG_EARLYEXIT DEBUG_RAYTERMSTEP DEBUG_HITFRACTION DEBUG_SDF DEBUG_PIXELINSPECTOR
 
             #pragma vertex Vert
             #pragma fragment Frag
@@ -49,6 +51,9 @@ Shader "Hidden/RainRust/RayTracing"
             float _NoiseIntensity; // 噪声强度
             float2 _NoiseVelocity; // 噪声移动速度
             int _NoiseType; // 噪声类型: 0-Value, 1-Perlin, 2-Simplex, 3-Voronoi
+
+            // Pixel Inspector 模式: 要检查的像素 UV
+            float2 _DebugPixelUV;
 
             // =======================================================================
 
@@ -146,8 +151,6 @@ Shader "Hidden/RainRust/RayTracing"
 
             float4 Frag(FragInputGI i) : SV_Target
             {
-                float3 result = _AmbientColor;
-
 #if defined(FRAGMENT_RANDOM)
                 const float rand = GetShaderNoise(i.noise_uv);
 #elif defined(TEXTURE_RANDOM)
@@ -155,6 +158,186 @@ Shader "Hidden/RainRust/RayTracing"
 #else
                 const float rand = 0;
 #endif
+
+// =======================================================================
+// Debug 可视化路径 (任一 keyword 开启时, 直接 return, 跳过正常 ray tracing)
+// =======================================================================
+#if defined(DEBUG_RAND)
+                // H1: 显示每像素 rand 值. 期望: 移动相机时图像不动 (噪声锚定在屏幕)
+                return float4(rand, rand, rand, 1);
+
+#elif defined(DEBUG_SAMPLEDIR)
+                // H1/H4: 显示第 0 条采样光线的方向 (R=cos, G=sin, 范围映射到 [0,1])
+                {
+                    const float t0 = (0 + rand) / _Samples * float(3.1415926 * 2.0);
+                    return float4(cos(t0) * 0.5 + 0.5, sin(t0) * 0.5 + 0.5, 0, 1);
+                }
+
+#elif defined(DEBUG_COLORALPHA)
+                // H2: 直接显示 _ColorTex 的 alpha 通道, 让你看到光源边缘是否有部分覆盖
+                {
+                    const float a = tex2D(_ColorTex, i.uv).a;
+                    return float4(a, a, a, 1);
+                }
+
+#elif defined(DEBUG_EARLYEXIT)
+                // H2: 红色 = 走 early-exit 直接返回光源色; 暗绿 = 走 ray marching 路径
+                {
+                    const float ea = tex2D(_ColorTex, i.uv).a;
+                    return (ea > 0) ? float4(1, 0, 0, 1) : float4(0, 0.25, 0, 1);
+                }
+
+#elif defined(DEBUG_SDF)
+                // Sanity: 直接显示 SDF
+                {
+                    const float d = tex2D(_DistTex, i.uv).r;
+                    return float4(d, d, d, 1);
+                }
+
+#elif defined(DEBUG_PIXELINSPECTOR)
+                // PixelInspector: 把 _DebugPixelUV 这个像素的全部 ray 数据铺满屏幕
+                //   - X 方向: ray 编号 (0 ~ _Samples-1)
+                //   - Y 方向: 8 个条带, 每个条带显示一个属性
+                {
+                    const int totalBands = 8;
+                    const int rayIdx = (int)floor(i.uv.x * _Samples);
+                    const int band = (int)floor(i.uv.y * totalBands);
+
+                    if (rayIdx < 0 || rayIdx >= (int)_Samples)
+                        return float4(0, 0, 0, 1);
+
+                    // 重新计算 _DebugPixelUV 的 rand (需要按其屏幕位置采样)
+#if defined(FRAGMENT_RANDOM)
+                    const float2 dbgNoiseUV = _DebugPixelUV * _NoiseTilingOffset.xy + _NoiseTilingOffset.zw;
+                    const float dbgRand = GetShaderNoise(dbgNoiseUV);
+#elif defined(TEXTURE_RANDOM)
+                    const float2 dbgNoiseUV = _DebugPixelUV * _NoiseTilingOffset.xy + _NoiseTilingOffset.zw;
+                    const float dbgRand = tex2D(_NoiseTex, dbgNoiseUV).r;
+#else
+                    const float dbgRand = 0;
+#endif
+
+                    const float t = (rayIdx + dbgRand) / _Samples * float(3.1415926 * 2.0);
+                    const float2 dir = float2(cos(t), sin(t)) / _Aspect.xy;
+
+                    float2 uvPos = _DebugPixelUV;
+                    float used = STEPS;
+                    float didHit = 0;
+                    float4 hitC = float4(0, 0, 0, 0);
+
+                    const float4 c0 = tex2D(_ColorTex, uvPos).rgba;
+                    if (c0.a > 0)
+                    {
+                        used = 0;
+                        didHit = 1;
+                        hitC = c0;
+                    }
+                    else
+                    {
+                        uvPos += dir * tex2D(_DistTex, uvPos).rr;
+                        if (NotUVSpace(uvPos))
+                        {
+                            used = 1;
+                        }
+                        else
+                        {
+                            [loop]
+                            for (int n = 1; n < STEPS; n++)
+                            {
+                                const float4 cn = tex2D(_ColorTex, uvPos).rgba;
+                                if (cn.a > 0)
+                                {
+                                    used = n;
+                                    didHit = 1;
+                                    hitC = cn;
+                                    break;
+                                }
+                                uvPos += dir * tex2D(_DistTex, uvPos).rr;
+                                if (NotUVSpace(uvPos))
+                                {
+                                    used = n;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    float attenuation = 0;
+                    float3 contribution = float3(0, 0, 0);
+                    if (didHit > 0)
+                    {
+                        attenuation = GTRAttenuation(
+                            (_DebugPixelUV - uvPos) * _Aspect.xy,
+                            _LightFalloffAlpha * hitC.a,
+                            _LightFalloffGamma
+                        );
+                        contribution = hitC.rgb * attenuation;
+                    }
+
+                    // 条带分发
+                    if (band == 0) return float4(didHit, didHit, didHit, 1);                              // 0: hit/miss
+                    if (band == 1) return float4(hitC.a, hitC.a, hitC.a, 1);                              // 1: bilinear hit alpha (关键嫌疑)
+                    if (band == 2) return float4(attenuation, attenuation, attenuation, 1);                // 2: attenuation
+                    if (band == 3) return float4(hitC.r, hitC.r, hitC.r, 1);                              // 3: hit color.r
+                    if (band == 4) return float4(hitC.g, hitC.g, hitC.g, 1);                              // 4: hit color.g
+                    if (band == 5) return float4(hitC.b, hitC.b, hitC.b, 1);                              // 5: hit color.b
+                    if (band == 6) { float s = used / float(STEPS); return float4(s, s, s, 1); }          // 6: 终止步数 / STEPS
+                    if (band == 7) { float m = length(contribution); return float4(m, m, m, 1); }         // 7: 贡献度
+
+                    return float4(0, 0, 0, 1);
+                }
+
+#elif defined(DEBUG_RAYTERMSTEP) || defined(DEBUG_HITFRACTION)
+                // H3: 重做 ray marching, 但记录每条光线的 "终止步数" 和 "是否命中光源"
+                //   - RayTermStep: 平均终止步数 / STEPS  (亮 = 接近用满步数, 是命中边界候选)
+                //   - HitFraction: 命中光源的光线占比 (亮 = 多数命中)
+                {
+                    float accSteps = 0;
+                    float hits = 0;
+
+                    for (float f = 0.; f < _Samples; f++)
+                    {
+                        const float t = (f + rand) / _Samples * float(3.1415926 * 2.0);
+                        const float2 dir = float2(cos(t), sin(t)) / _Aspect.xy;
+                        float2 uvPos = i.uv;
+                        float used = STEPS;
+                        float didHit = 0;
+
+                        const float4 c0 = tex2D(_ColorTex, uvPos).rgba;
+                        if (c0.a > 0)
+                        {
+                            used = 0;
+                            didHit = 1;
+                        }
+                        else
+                        {
+                            [loop]
+                            for (int n = 1; n < STEPS; n++)
+                            {
+                                uvPos += dir * tex2D(_DistTex, uvPos).rr;
+                                if (NotUVSpace(uvPos)) { used = n; break; }
+                                const float4 cn = tex2D(_ColorTex, uvPos).rgba;
+                                if (cn.a > 0) { used = n; didHit = 1; break; }
+                            }
+                        }
+
+                        accSteps += used;
+                        hits += didHit;
+                    }
+
+                    #if defined(DEBUG_RAYTERMSTEP)
+                    const float avg = accSteps / _Samples / float(STEPS);
+                    return float4(avg, avg, avg, 1);
+                    #else
+                    const float frac = hits / _Samples;
+                    return float4(frac, frac, frac, 1);
+                    #endif
+                }
+#else
+// =======================================================================
+// 正常渲染路径 (无 DEBUG keyword)
+// =======================================================================
+                float3 result = _AmbientColor;
 
                 // 发射光线
                 for (float f = 0.; f < _Samples; f++)
@@ -169,18 +352,19 @@ Shader "Hidden/RainRust/RayTracing"
                 result *= _Intensity;
 
                 // Alpha 通道处理
-#if   defined(ONE_ALPHA)
+                #if   defined(ONE_ALPHA)
                 return float4(result, 1);
-                
-#elif defined(OBJECTS_MASK_ALPHA)
+
+                #elif defined(OBJECTS_MASK_ALPHA)
                 const float mask = tex2D(_ColorTex, i.uv).a;
                 return float4(result, mask);
-                
-#elif defined(NORMALIZED_ALPHA)
+
+                #elif defined(NORMALIZED_ALPHA)
                 // 颜色归一化, Alpha 作为不透明度
                 float norm = max(result.r, max(result.g, result.b));
                 return float4(result / norm, norm);
-#endif
+                #endif
+#endif // DEBUG modes
             }
             ENDHLSL
         }

--- a/Assets/Rendering/RainRust/Shaders/RayTracing.shader
+++ b/Assets/Rendering/RainRust/Shaders/RayTracing.shader
@@ -28,7 +28,7 @@ Shader "Hidden/RainRust/RayTracing"
             // 输出alpha通道方式: 全部为1, 使用对象遮罩, 颜色归一化后最大值
             #pragma multi_compile_local ONE_ALPHA OBJECTS_MASK_ALPHA NORMALIZED_ALPHA
             // Debug 可视化模式 (_ 表示关闭, 即正常渲染)
-            #pragma multi_compile_local _ DEBUG_RAND DEBUG_SAMPLEDIR DEBUG_COLORALPHA DEBUG_EARLYEXIT DEBUG_RAYTERMSTEP DEBUG_HITFRACTION DEBUG_SDF DEBUG_PIXELINSPECTOR
+            #pragma multi_compile_local _ DEBUG_RAND DEBUG_SAMPLEDIR DEBUG_COLORALPHA DEBUG_EARLYEXIT DEBUG_RAYTERMSTEP DEBUG_HITFRACTION DEBUG_SDF DEBUG_PIXELINSPECTOR DEBUG_GTRBREAKDOWN
 
             #pragma vertex Vert
             #pragma fragment Frag
@@ -196,93 +196,241 @@ Shader "Hidden/RainRust/RayTracing"
 
 #elif defined(DEBUG_PIXELINSPECTOR)
                 // PixelInspector: 把 _DebugPixelUV 这个像素的全部 ray 数据铺满屏幕
-                //   - X 方向: ray 编号 (0 ~ _Samples-1)
-                //   - Y 方向: 8 个条带, 每个条带显示一个属性
+                //   - X 方向: ray 编号 0 .. _Samples-1
+                //   - Y 方向: 6 个条带
+                //   - 7 个条带 (从 Y=0 即屏幕顶端往下):
+                //       0: hit/miss (1/0)
+                //       1: contribution RGB  (color*atten | color/alpha | _AmbientColor)
+                //       2: share = length(thisContrib) / sum_k length(contrib_k)
+                //       3: used / STEPS
+                //       4: GTR attenuation
+                //       5: 光线方向 (R=cos*0.5+0.5, G=sin*0.5+0.5)
+                //       6: 最终像素颜色 (与正常 Frag 一致, 所有列应相同)
                 {
-                    const int totalBands = 8;
-                    const int rayIdx = (int)floor(i.uv.x * _Samples);
+                    const int totalBands = 7;
+                    const int N = clamp((int)_Samples, 1, 64);
+                    const int rayIdx = (int)floor(i.uv.x * N);
                     const int band = (int)floor(i.uv.y * totalBands);
 
-                    if (rayIdx < 0 || rayIdx >= (int)_Samples)
+                    if (rayIdx < 0 || rayIdx >= N)
+                        return float4(0, 0, 0, 1);
+                    if (band < 0 || band >= totalBands)
                         return float4(0, 0, 0, 1);
 
-                    // 重新计算 _DebugPixelUV 的 rand (需要按其屏幕位置采样)
-#if defined(FRAGMENT_RANDOM)
+                    // _DebugPixelUV 处的 rand (按其屏幕坐标采样, 与正常渲染一致)
+                    #if defined(FRAGMENT_RANDOM)
                     const float2 dbgNoiseUV = _DebugPixelUV * _NoiseTilingOffset.xy + _NoiseTilingOffset.zw;
                     const float dbgRand = GetShaderNoise(dbgNoiseUV);
-#elif defined(TEXTURE_RANDOM)
+                    #elif defined(TEXTURE_RANDOM)
                     const float2 dbgNoiseUV = _DebugPixelUV * _NoiseTilingOffset.xy + _NoiseTilingOffset.zw;
                     const float dbgRand = tex2D(_NoiseTex, dbgNoiseUV).r;
-#else
+                    #else
                     const float dbgRand = 0;
-#endif
+                    #endif
 
-                    const float t = (rayIdx + dbgRand) / _Samples * float(3.1415926 * 2.0);
-                    const float2 dir = float2(cos(t), sin(t)) / _Aspect.xy;
+                    // 一次循环遍历所有光线: 边走边累 sumMag / sumContrib, 记录 thisRay 的细节
+                    float  sumMag     = 0;
+                    float3 sumContrib = float3(0, 0, 0);
 
-                    float2 uvPos = _DebugPixelUV;
-                    float used = STEPS;
-                    float didHit = 0;
-                    float4 hitC = float4(0, 0, 0, 0);
+                    // thisRay 默认值 = miss 语义
+                    float  thisHit     = 0;
+                    float3 thisContrib = _AmbientColor;
+                    float  thisAtten   = 0;
+                    float  thisUsed    = STEPS;
+                    float2 thisDir     = float2(0, 0);
 
-                    const float4 c0 = tex2D(_ColorTex, uvPos).rgba;
+                    [loop]
+                    for (int r = 0; r < N; r++)
+                    {
+                        const float  tR    = (r + dbgRand) / float(N) * float(3.1415926 * 2.0);
+                        const float2 dirR  = float2(cos(tR), sin(tR));   // 原始单位方向
+                        const float2 dirRA = dirR / _Aspect.xy;          // ray marching 用的 aspect 修正方向
+
+                        // 每条光线的局部变量都在迭代内显式声明 + 初始化, 避免编译器跨迭代复用
+                        float2 uvP     = _DebugPixelUV;
+                        float  usedR   = STEPS;
+                        float  hitR    = 0;
+                        float  attenR  = 0;
+                        float3 contribR = _AmbientColor;   // miss 默认贡献 = 环境光
+
+                        const float4 c0 = tex2D(_ColorTex, uvP).rgba;
+                        if (c0.a > 0)
+                        {
+                            // 起点就在光源上 (原 Trace 的 early-exit 路径)
+                            usedR    = 0;
+                            hitR     = 1;
+                            attenR   = 1;
+                            contribR = c0.rgb / c0.a;
+                        }
+                        else
+                        {
+                            uvP += dirRA * tex2D(_DistTex, uvP).rr;
+                            if (NotUVSpace(uvP))
+                            {
+                                usedR = 1;
+                                // miss; contribR 保持 _AmbientColor
+                            }
+                            else
+                            {
+                                [loop]
+                                for (int n = 1; n < STEPS; n++)
+                                {
+                                    const float4 cn = tex2D(_ColorTex, uvP).rgba;
+                                    if (cn.a > 0)
+                                    {
+                                        usedR    = n;
+                                        hitR     = 1;
+                                        attenR   = GTRAttenuation(
+                                            (_DebugPixelUV - uvP) * _Aspect.xy,
+                                            _LightFalloffAlpha * cn.a,
+                                            _LightFalloffGamma
+                                        );
+                                        contribR = cn.rgb * attenR;
+                                        break;
+                                    }
+                                    uvP += dirRA * tex2D(_DistTex, uvP).rr;
+                                    if (NotUVSpace(uvP))
+                                    {
+                                        usedR = n;
+                                        break;
+                                    }
+                                }
+                                // 自然走完循环未命中: contribR 保持 _AmbientColor
+                            }
+                        }
+
+                        sumMag     += length(contribR);
+                        sumContrib += contribR;
+
+                        if (r == rayIdx)
+                        {
+                            thisHit     = hitR;
+                            thisContrib = contribR;
+                            thisAtten   = attenR;
+                            thisUsed    = usedR;
+                            thisDir     = dirR;
+                        }
+                    }
+
+                    const float thisMag = length(thisContrib);
+                    const float share   = sumMag > 1e-6 ? thisMag / sumMag : 0;
+
+                    if (band == 0) return float4(thisHit, thisHit, thisHit, 1);
+                    if (band == 1) return float4(thisContrib, 1);
+                    if (band == 2) return float4(share, share, share, 1);
+                    if (band == 3) { const float s = thisUsed / float(STEPS); return float4(s, s, s, 1); }
+                    if (band == 4) return float4(thisAtten, thisAtten, thisAtten, 1);
+                    if (band == 5) return float4(thisDir.x * 0.5 + 0.5, thisDir.y * 0.5 + 0.5, 0, 1);
+                    if (band == 6)
+                    {
+                        // 最终像素颜色: 与正常 Frag 路径完全一致
+                        //   result = _AmbientColor + sum(per-ray contribR); result /= N; result *= _Intensity
+                        const float3 finalRGB = (_AmbientColor + sumContrib) / float(N) * _Intensity;
+                        return float4(finalRGB, 1);
+                    }
+
+                    return float4(0, 0, 0, 1);
+                }
+
+#elif defined(DEBUG_GTRBREAKDOWN)
+                // GTRBreakdown: 把 _DebugPixelUV 这个像素的 GTR 输入分量铺满屏幕
+                //   - X 方向: ray 编号 0 .. _Samples-1 (与 PixelInspector 列对齐)
+                //   - Y 方向: 7 个条带
+                //   - 7 个条带 (从 Y=0 即屏幕顶端往下):
+                //       0: hit/miss (1/0) sanity
+                //       1: x = length((uv - hitUV) * aspect)  [灰度, 原值]
+                //       2: cn.a  [灰度, 0..1, bilinear 命中点 alpha]
+                //       3: eff_alpha = _LightFalloffAlpha * cn.a  [灰度]
+                //       4: x / eff_alpha  [灰度, saturate 到 [0,1]]
+                //       5: GTR 最终值  [灰度, 0..1]
+                //       6: 命中 UV (R=hitUV.x, G=hitUV.y)
+                //
+                //   用法: RenderDoc 抓两次 (相机移动前/后), 对比同一列各 band 的精确数值;
+                //         band 1 跳 → 是命中距离在跳
+                //         band 2 跳 → 是 _ColorTex bilinear 出来的 alpha 在跳
+                //         band 6 跳 → 是命中点位置 (texel) 本身在跳
+                {
+                    const int totalBands = 7;
+                    const int N = clamp((int)_Samples, 1, 64);
+                    const int rayIdx = (int)floor(i.uv.x * N);
+                    const int band = (int)floor(i.uv.y * totalBands);
+
+                    if (rayIdx < 0 || rayIdx >= N)
+                        return float4(0, 0, 0, 1);
+                    if (band < 0 || band >= totalBands)
+                        return float4(0, 0, 0, 1);
+
+                    // _DebugPixelUV 处的 rand (按其屏幕坐标采样, 与正常渲染一致)
+                    #if defined(FRAGMENT_RANDOM)
+                    const float2 dbgNoiseUV = _DebugPixelUV * _NoiseTilingOffset.xy + _NoiseTilingOffset.zw;
+                    const float dbgRand = GetShaderNoise(dbgNoiseUV);
+                    #elif defined(TEXTURE_RANDOM)
+                    const float2 dbgNoiseUV = _DebugPixelUV * _NoiseTilingOffset.xy + _NoiseTilingOffset.zw;
+                    const float dbgRand = tex2D(_NoiseTex, dbgNoiseUV).r;
+                    #else
+                    const float dbgRand = 0;
+                    #endif
+
+                    // 只重做 rayIdx 这一条光线的 ray-march, 拿到它的 GTR 输入分量
+                    const float  tR    = (rayIdx + dbgRand) / float(N) * float(3.1415926 * 2.0);
+                    const float2 dirR  = float2(cos(tR), sin(tR));
+                    const float2 dirRA = dirR / _Aspect.xy;
+
+                    float2 uvP    = _DebugPixelUV;
+                    float  hitR   = 0;
+                    float  hitA   = 0;          // cn.a 命中点 alpha
+                    float2 hitUV  = float2(0, 0);
+
+                    const float4 c0 = tex2D(_ColorTex, uvP).rgba;
                     if (c0.a > 0)
                     {
-                        used = 0;
-                        didHit = 1;
-                        hitC = c0;
+                        // 起点就在光源上, 距离 = 0, alpha = 起点 alpha
+                        hitR  = 1;
+                        hitA  = c0.a;
+                        hitUV = uvP;
                     }
                     else
                     {
-                        uvPos += dir * tex2D(_DistTex, uvPos).rr;
-                        if (NotUVSpace(uvPos))
-                        {
-                            used = 1;
-                        }
-                        else
+                        uvP += dirRA * tex2D(_DistTex, uvP).rr;
+                        if (!NotUVSpace(uvP))
                         {
                             [loop]
                             for (int n = 1; n < STEPS; n++)
                             {
-                                const float4 cn = tex2D(_ColorTex, uvPos).rgba;
+                                const float4 cn = tex2D(_ColorTex, uvP).rgba;
                                 if (cn.a > 0)
                                 {
-                                    used = n;
-                                    didHit = 1;
-                                    hitC = cn;
+                                    hitR  = 1;
+                                    hitA  = cn.a;
+                                    hitUV = uvP;
                                     break;
                                 }
-                                uvPos += dir * tex2D(_DistTex, uvPos).rr;
-                                if (NotUVSpace(uvPos))
-                                {
-                                    used = n;
+                                uvP += dirRA * tex2D(_DistTex, uvP).rr;
+                                if (NotUVSpace(uvP))
                                     break;
-                                }
                             }
                         }
                     }
 
-                    float attenuation = 0;
-                    float3 contribution = float3(0, 0, 0);
-                    if (didHit > 0)
+                    if (band == 0) return float4(hitR, hitR, hitR, 1);
+                    if (hitR < 0.5)
                     {
-                        attenuation = GTRAttenuation(
-                            (_DebugPixelUV - uvPos) * _Aspect.xy,
-                            _LightFalloffAlpha * hitC.a,
-                            _LightFalloffGamma
-                        );
-                        contribution = hitC.rgb * attenuation;
+                        // miss: 距离/alpha/GTR 都没有意义, 全显黑, 但 band 6 仍显示当前 uvP 帮助看出射范围
+                        if (band == 6) return float4(uvP.x, uvP.y, 0, 1);
+                        return float4(0, 0, 0, 1);
                     }
 
-                    // 条带分发
-                    if (band == 0) return float4(didHit, didHit, didHit, 1);                              // 0: hit/miss
-                    if (band == 1) return float4(hitC.a, hitC.a, hitC.a, 1);                              // 1: bilinear hit alpha (关键嫌疑)
-                    if (band == 2) return float4(attenuation, attenuation, attenuation, 1);                // 2: attenuation
-                    if (band == 3) return float4(hitC.r, hitC.r, hitC.r, 1);                              // 3: hit color.r
-                    if (band == 4) return float4(hitC.g, hitC.g, hitC.g, 1);                              // 4: hit color.g
-                    if (band == 5) return float4(hitC.b, hitC.b, hitC.b, 1);                              // 5: hit color.b
-                    if (band == 6) { float s = used / float(STEPS); return float4(s, s, s, 1); }          // 6: 终止步数 / STEPS
-                    if (band == 7) { float m = length(contribution); return float4(m, m, m, 1); }         // 7: 贡献度
+                    const float  x        = length((_DebugPixelUV - hitUV) * _Aspect.xy);
+                    const float  effAlpha = _LightFalloffAlpha * hitA;
+                    const float  ratio    = effAlpha > 1e-8 ? (x / effAlpha) : 1e8;
+                    const float  gtr      = 1.0 / pow(1.0 + pow(ratio, 2.0), _LightFalloffGamma);
+
+                    if (band == 1) return float4(x, x, x, 1);
+                    if (band == 2) return float4(hitA, hitA, hitA, 1);
+                    if (band == 3) return float4(effAlpha, effAlpha, effAlpha, 1);
+                    if (band == 4) { const float r = saturate(ratio); return float4(r, r, r, 1); }
+                    if (band == 5) return float4(gtr, gtr, gtr, 1);
+                    if (band == 6) return float4(hitUV.x, hitUV.y, 0, 1);
 
                     return float4(0, 0, 0, 1);
                 }

--- a/Assets/Rendering/RainRust/Shaders/RayTracing.shader
+++ b/Assets/Rendering/RainRust/Shaders/RayTracing.shader
@@ -33,7 +33,9 @@ Shader "Hidden/RainRust/RayTracing"
             #pragma vertex Vert
             #pragma fragment Frag
 
-            sampler2D _ColorTex; // 场景颜色纹理
+            TEXTURE2D(_ColorTex); // 场景颜色纹理
+            SAMPLER(sampler_ColorTex);   // 跟随纹理 import filter (bilinear)
+            // sampler_PointClamp 由 URP Core.hlsl 提供; 仅用于 GTR 的 cn.a 输入, 避免次像素 bilinear 抖动
             sampler2D _DistTex; // 场景距离纹理 (SDF)
             sampler2D _NoiseTex; // 随机噪声纹理
 
@@ -79,7 +81,7 @@ Shader "Hidden/RainRust/RayTracing"
                 float2 uvPos = uv; // 当前采样坐标
 
                 // 若起始点已在光源上, 直接返回颜色
-                const float4 color = tex2D(_ColorTex, uv).rgba;
+                const float4 color = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uv).rgba;
                 if (color.a > 0)
                     return color.rgb / color.a;
                 
@@ -91,11 +93,11 @@ Shader "Hidden/RainRust/RayTracing"
                 [unroll]
                 for (int n = 1; n < STEPS; n++)
                 {
-                    const float4 color = tex2D(_ColorTex, uvPos).rgba;
+                    const float4 color = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvPos).rgba;
                     if (color.a > 0)
                     {
-                        // 使用 GTR 衰减
-                        float attenuation = GTRAttenuation((uv - uvPos) * _Aspect.xy, _LightFalloffAlpha * color.a, _LightFalloffGamma);
+                        // GTR 衰减
+                        float attenuation = GTRAttenuation((uv - uvPos) * _Aspect.xy, _LightFalloffAlpha, _LightFalloffGamma);
                         return color.rgb * attenuation;
                     }
 
@@ -176,14 +178,14 @@ Shader "Hidden/RainRust/RayTracing"
 #elif defined(DEBUG_COLORALPHA)
                 // H2: 直接显示 _ColorTex 的 alpha 通道, 让你看到光源边缘是否有部分覆盖
                 {
-                    const float a = tex2D(_ColorTex, i.uv).a;
+                    const float a = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,i.uv).a;
                     return float4(a, a, a, 1);
                 }
 
 #elif defined(DEBUG_EARLYEXIT)
                 // H2: 红色 = 走 early-exit 直接返回光源色; 暗绿 = 走 ray marching 路径
                 {
-                    const float ea = tex2D(_ColorTex, i.uv).a;
+                    const float ea = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,i.uv).a;
                     return (ea > 0) ? float4(1, 0, 0, 1) : float4(0, 0.25, 0, 1);
                 }
 
@@ -197,17 +199,18 @@ Shader "Hidden/RainRust/RayTracing"
 #elif defined(DEBUG_PIXELINSPECTOR)
                 // PixelInspector: 把 _DebugPixelUV 这个像素的全部 ray 数据铺满屏幕
                 //   - X 方向: ray 编号 0 .. _Samples-1
-                //   - Y 方向: 6 个条带
-                //   - 7 个条带 (从 Y=0 即屏幕顶端往下):
+                //   - Y 方向: 9 个条带 (从 Y=0 即屏幕顶端往下):
                 //       0: hit/miss (1/0)
-                //       1: contribution RGB  (color*atten | color/alpha | _AmbientColor)
-                //       2: share = length(thisContrib) / sum_k length(contrib_k)
-                //       3: used / STEPS
-                //       4: GTR attenuation
-                //       5: 光线方向 (R=cos*0.5+0.5, G=sin*0.5+0.5)
-                //       6: 最终像素颜色 (与正常 Frag 一致, 所有列应相同)
+                //       1: 命中光源原色 (cn.rgb / cn.a, 无衰减; miss 显黑)
+                //       2: contribution RGB  (color*atten | color/alpha | _AmbientColor)
+                //       3: share = length(thisContrib) / sum_k length(contrib_k)
+                //       4: used / STEPS
+                //       5: GTR attenuation
+                //       6: 光线方向 (R=cos*0.5+0.5, G=sin*0.5+0.5)
+                //       7: 最终像素颜色 (与正常 Frag 一致, 所有列应相同)
+                //       8: 命中光源 UV (R=hitUV.x, G=hitUV.y; miss 显纯蓝 0,0,1)
                 {
-                    const int totalBands = 7;
+                    const int totalBands = 9;
                     const int N = clamp((int)_Samples, 1, 64);
                     const int rayIdx = (int)floor(i.uv.x * N);
                     const int band = (int)floor(i.uv.y * totalBands);
@@ -233,11 +236,14 @@ Shader "Hidden/RainRust/RayTracing"
                     float3 sumContrib = float3(0, 0, 0);
 
                     // thisRay 默认值 = miss 语义
-                    float  thisHit     = 0;
-                    float3 thisContrib = _AmbientColor;
-                    float  thisAtten   = 0;
-                    float  thisUsed    = STEPS;
-                    float2 thisDir     = float2(0, 0);
+                    float  thisHit       = 0;
+                    float3 thisLightCol  = float3(0, 0, 0);
+                    float3 thisContrib   = _AmbientColor;
+                    float  thisAtten     = 0;
+                    float  thisUsed      = STEPS;
+                    float2 thisDir       = float2(0, 0);
+                    float2 thisHitUV     = float2(0, 0);
+                    float  thisHasHitUV  = 0;
 
                     [loop]
                     for (int r = 0; r < N; r++)
@@ -247,20 +253,26 @@ Shader "Hidden/RainRust/RayTracing"
                         const float2 dirRA = dirR / _Aspect.xy;          // ray marching 用的 aspect 修正方向
 
                         // 每条光线的局部变量都在迭代内显式声明 + 初始化, 避免编译器跨迭代复用
-                        float2 uvP     = _DebugPixelUV;
-                        float  usedR   = STEPS;
-                        float  hitR    = 0;
-                        float  attenR  = 0;
-                        float3 contribR = _AmbientColor;   // miss 默认贡献 = 环境光
+                        float2 uvP        = _DebugPixelUV;
+                        float  usedR      = STEPS;
+                        float  hitR       = 0;
+                        float  attenR     = 0;
+                        float3 contribR   = _AmbientColor;   // miss 默认贡献 = 环境光
+                        float3 lightColR  = float3(0, 0, 0); // 命中光源原色 (无衰减); miss 显黑
+                        float2 hitUVR     = float2(0, 0);
+                        float  hasHitUVR  = 0;
 
-                        const float4 c0 = tex2D(_ColorTex, uvP).rgba;
+                        const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uvP).rgba;
                         if (c0.a > 0)
                         {
                             // 起点就在光源上 (原 Trace 的 early-exit 路径)
-                            usedR    = 0;
-                            hitR     = 1;
-                            attenR   = 1;
-                            contribR = c0.rgb / c0.a;
+                            usedR     = 0;
+                            hitR      = 1;
+                            attenR    = 1;
+                            contribR  = c0.rgb / c0.a;
+                            lightColR = c0.rgb / c0.a;
+                            hitUVR    = uvP;
+                            hasHitUVR = 1;
                         }
                         else
                         {
@@ -275,17 +287,20 @@ Shader "Hidden/RainRust/RayTracing"
                                 [loop]
                                 for (int n = 1; n < STEPS; n++)
                                 {
-                                    const float4 cn = tex2D(_ColorTex, uvP).rgba;
+                                    const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
                                     if (cn.a > 0)
                                     {
-                                        usedR    = n;
-                                        hitR     = 1;
-                                        attenR   = GTRAttenuation(
+                                        usedR     = n;
+                                        hitR      = 1;
+                                        attenR    = GTRAttenuation(
                                             (_DebugPixelUV - uvP) * _Aspect.xy,
-                                            _LightFalloffAlpha * cn.a,
+                                            _LightFalloffAlpha,
                                             _LightFalloffGamma
                                         );
-                                        contribR = cn.rgb * attenR;
+                                        contribR  = cn.rgb * attenR;
+                                        lightColR = cn.rgb / cn.a;
+                                        hitUVR    = uvP;
+                                        hasHitUVR = 1;
                                         break;
                                     }
                                     uvP += dirRA * tex2D(_DistTex, uvP).rr;
@@ -304,11 +319,14 @@ Shader "Hidden/RainRust/RayTracing"
 
                         if (r == rayIdx)
                         {
-                            thisHit     = hitR;
-                            thisContrib = contribR;
-                            thisAtten   = attenR;
-                            thisUsed    = usedR;
-                            thisDir     = dirR;
+                            thisHit      = hitR;
+                            thisLightCol = lightColR;
+                            thisContrib  = contribR;
+                            thisAtten    = attenR;
+                            thisUsed     = usedR;
+                            thisDir      = dirR;
+                            thisHitUV    = hitUVR;
+                            thisHasHitUV = hasHitUVR;
                         }
                     }
 
@@ -316,17 +334,24 @@ Shader "Hidden/RainRust/RayTracing"
                     const float share   = sumMag > 1e-6 ? thisMag / sumMag : 0;
 
                     if (band == 0) return float4(thisHit, thisHit, thisHit, 1);
-                    if (band == 1) return float4(thisContrib, 1);
-                    if (band == 2) return float4(share, share, share, 1);
-                    if (band == 3) { const float s = thisUsed / float(STEPS); return float4(s, s, s, 1); }
-                    if (band == 4) return float4(thisAtten, thisAtten, thisAtten, 1);
-                    if (band == 5) return float4(thisDir.x * 0.5 + 0.5, thisDir.y * 0.5 + 0.5, 0, 1);
-                    if (band == 6)
+                    if (band == 1) return float4(thisLightCol, 1);
+                    if (band == 2) return float4(thisContrib, 1);
+                    if (band == 3) return float4(share, share, share, 1);
+                    if (band == 4) { const float s = thisUsed / float(STEPS); return float4(s, s, s, 1); }
+                    if (band == 5) return float4(thisAtten, thisAtten, thisAtten, 1);
+                    if (band == 6) return float4(thisDir.x * 0.5 + 0.5, thisDir.y * 0.5 + 0.5, 0, 1);
+                    if (band == 7)
                     {
                         // 最终像素颜色: 与正常 Frag 路径完全一致
                         //   result = _AmbientColor + sum(per-ray contribR); result /= N; result *= _Intensity
                         const float3 finalRGB = (_AmbientColor + sumContrib) / float(N) * _Intensity;
                         return float4(finalRGB, 1);
+                    }
+                    if (band == 8)
+                    {
+                        if (thisHasHitUV < 0.5)
+                            return float4(0, 0, 1, 1); // miss: 纯蓝
+                        return float4(thisHitUV.x, thisHitUV.y, 0, 1);
                     }
 
                     return float4(0, 0, 0, 1);
@@ -344,11 +369,7 @@ Shader "Hidden/RainRust/RayTracing"
                 //       4: x / eff_alpha  [灰度, saturate 到 [0,1]]
                 //       5: GTR 最终值  [灰度, 0..1]
                 //       6: 命中 UV (R=hitUV.x, G=hitUV.y)
-                //
-                //   用法: RenderDoc 抓两次 (相机移动前/后), 对比同一列各 band 的精确数值;
-                //         band 1 跳 → 是命中距离在跳
-                //         band 2 跳 → 是 _ColorTex bilinear 出来的 alpha 在跳
-                //         band 6 跳 → 是命中点位置 (texel) 本身在跳
+
                 {
                     const int totalBands = 7;
                     const int N = clamp((int)_Samples, 1, 64);
@@ -381,12 +402,12 @@ Shader "Hidden/RainRust/RayTracing"
                     float  hitA   = 0;          // cn.a 命中点 alpha
                     float2 hitUV  = float2(0, 0);
 
-                    const float4 c0 = tex2D(_ColorTex, uvP).rgba;
+                    // 注意: hit 判定仍走 bilinear (与正常渲染一致), 但 hitA 用 point 采样
+                    const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
                     if (c0.a > 0)
                     {
-                        // 起点就在光源上, 距离 = 0, alpha = 起点 alpha
                         hitR  = 1;
-                        hitA  = c0.a;
+                        hitA  = SAMPLE_TEXTURE2D(_ColorTex, sampler_PointClamp, uvP).a;
                         hitUV = uvP;
                     }
                     else
@@ -397,11 +418,11 @@ Shader "Hidden/RainRust/RayTracing"
                             [loop]
                             for (int n = 1; n < STEPS; n++)
                             {
-                                const float4 cn = tex2D(_ColorTex, uvP).rgba;
+                                const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex, uvP).rgba;
                                 if (cn.a > 0)
                                 {
                                     hitR  = 1;
-                                    hitA  = cn.a;
+                                    hitA  = SAMPLE_TEXTURE2D(_ColorTex, sampler_PointClamp, uvP).a;
                                     hitUV = uvP;
                                     break;
                                 }
@@ -421,13 +442,13 @@ Shader "Hidden/RainRust/RayTracing"
                     }
 
                     const float  x        = length((_DebugPixelUV - hitUV) * _Aspect.xy);
-                    const float  effAlpha = _LightFalloffAlpha * hitA;
+                    const float  effAlpha = _LightFalloffAlpha; // 不再 * hitA
                     const float  ratio    = effAlpha > 1e-8 ? (x / effAlpha) : 1e8;
                     const float  gtr      = 1.0 / pow(1.0 + pow(ratio, 2.0), _LightFalloffGamma);
 
                     if (band == 1) return float4(x, x, x, 1);
-                    if (band == 2) return float4(hitA, hitA, hitA, 1);
-                    if (band == 3) return float4(effAlpha, effAlpha, effAlpha, 1);
+                    if (band == 2) return float4(hitA, hitA, hitA, 1); // 仅 sanity, 不再喂 GTR
+                    if (band == 3) return float4(effAlpha, effAlpha, effAlpha, 1); // 常数: _LightFalloffAlpha
                     if (band == 4) { const float r = saturate(ratio); return float4(r, r, r, 1); }
                     if (band == 5) return float4(gtr, gtr, gtr, 1);
                     if (band == 6) return float4(hitUV.x, hitUV.y, 0, 1);
@@ -451,7 +472,7 @@ Shader "Hidden/RainRust/RayTracing"
                         float used = STEPS;
                         float didHit = 0;
 
-                        const float4 c0 = tex2D(_ColorTex, uvPos).rgba;
+                        const float4 c0 = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uvPos).rgba;
                         if (c0.a > 0)
                         {
                             used = 0;
@@ -464,7 +485,7 @@ Shader "Hidden/RainRust/RayTracing"
                             {
                                 uvPos += dir * tex2D(_DistTex, uvPos).rr;
                                 if (NotUVSpace(uvPos)) { used = n; break; }
-                                const float4 cn = tex2D(_ColorTex, uvPos).rgba;
+                                const float4 cn = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,uvPos).rgba;
                                 if (cn.a > 0) { used = n; didHit = 1; break; }
                             }
                         }
@@ -504,7 +525,7 @@ Shader "Hidden/RainRust/RayTracing"
                 return float4(result, 1);
 
                 #elif defined(OBJECTS_MASK_ALPHA)
-                const float mask = tex2D(_ColorTex, i.uv).a;
+                const float mask = SAMPLE_TEXTURE2D(_ColorTex, sampler_ColorTex,i.uv).a;
                 return float4(result, mask);
 
                 #elif defined(NORMALIZED_ALPHA)

--- a/Assets/Rendering/RainRust/Shaders/Unpremultiply.shader
+++ b/Assets/Rendering/RainRust/Shaders/Unpremultiply.shader
@@ -1,0 +1,48 @@
+Shader "Hidden/RainRust/Unpremultiply"
+{
+    SubShader
+    {
+        Tags { "RenderPipeline" = "UniversalPipeline" }
+
+        Pass
+        {
+            Name "Unpremultiply"
+
+            ZWrite Off
+            ZTest Always
+            Cull Off
+
+            HLSLPROGRAM
+            #include "Utils.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            #pragma vertex Vert
+            #pragma fragment Frag
+
+            // AddBlitPass 自动绑定
+            TEXTURE2D(_BlitTexture);
+            SAMPLER(sampler_BlitTexture);
+
+            FragInput Vert(uint vertexID : SV_VertexID)
+            {
+                FragInput o;
+                float2 uv = float2((vertexID << 1) & 2, vertexID & 2);
+                o.uv = uv;
+                o.vertex = float4(uv * 2.0 - 1.0, 0.0, 1.0);
+#if UNITY_UV_STARTS_AT_TOP
+                o.uv.y = 1.0 - o.uv.y;
+#endif
+                return o;
+            }
+
+            float4 Frag(const FragInput i) : SV_Target
+            {
+                float4 c = SAMPLE_TEXTURE2D(_BlitTexture, sampler_BlitTexture, i.uv);
+                if (c.a > 1e-4)
+                    return float4(c.rgb / c.a, c.a);
+                return float4(0, 0, 0, 0);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Rendering/RainRust/Shaders/Unpremultiply.shader.meta
+++ b/Assets/Rendering/RainRust/Shaders/Unpremultiply.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 529b71fe6af22c2448df2d9f0ed024d4
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rendering/RainRust/Volume/RainRustVolume.cs
+++ b/Assets/Rendering/RainRust/Volume/RainRustVolume.cs
@@ -70,5 +70,6 @@ namespace RainRust.Rendering
         HitFraction = 6,
         Sdf = 7,
         PixelInspector = 8,
+        GTRBreakdown = 9,
     }
 }

--- a/Assets/Rendering/RainRust/Volume/RainRustVolume.cs
+++ b/Assets/Rendering/RainRust/Volume/RainRustVolume.cs
@@ -26,6 +26,12 @@ namespace RainRust.Rendering
         public ClampedFloatParameter lightFalloffGamma = new(2.0f, 0.001f, 10f);
         public ColorParameter ambientColor = new(Color.black);
 
+        [Header("Debug")]
+        public EnumParameter<RainRustDebugMode> debugMode = new(RainRustDebugMode.None);
+
+        // 仅在 debugMode == PixelInspector 时使用; 屏幕 UV, 默认中心
+        public Vector2Parameter debugPixelUV = new(new Vector2(0.5f, 0.5f));
+
         public bool IsActive() => isEnabled.value;
 
         public bool IsTileCompatible() => false;
@@ -51,5 +57,18 @@ namespace RainRust.Rendering
         OneAlpha,
         ObjectsMaskAlpha,
         NormalizedAlpha,
+    }
+
+    public enum RainRustDebugMode
+    {
+        None = 0,
+        Rand = 1,
+        SampleDir = 2,
+        ColorAlpha = 3,
+        EarlyExit = 4,
+        RayTermStep = 5,
+        HitFraction = 6,
+        Sdf = 7,
+        PixelInspector = 8,
     }
 }

--- a/Assets/Rendering/RainRust/Volume/RainRustVolume.cs
+++ b/Assets/Rendering/RainRust/Volume/RainRustVolume.cs
@@ -24,6 +24,7 @@ namespace RainRust.Rendering
         public ClampedFloatParameter lightIntensity = new(0f, 0f, 10f);
         public ClampedFloatParameter lightFalloffAlpha = new(0.1f, 0.001f, 1f);
         public ClampedFloatParameter lightFalloffGamma = new(2.0f, 0.001f, 10f);
+        public ClampedFloatParameter lightHitThreshold = new(0.1f, 0f, 1f);
         public ColorParameter ambientColor = new(Color.black);
 
         [Header("Debug")]


### PR DESCRIPTION
## Summary

围绕 `RainRust` 光照管线做两件事:

1. **修复 alpha 语义不一致** — `_ColorTex` 之前在 `DrawObjects` (`Blend SrcAlpha OneMinusSrcAlpha`) 之后是 premultiplied (`rgb = lightColor * a`), 但下游 `RayTracing.shader` 同时存在两种假设: early-exit 用 `c.rgb / c.a` (假设 premul), ray-march 用 `c.rgb * atten` (假设 straight)。两套语义混用会在边缘 bilinear 区域产生不一致的颜色行为。
2. **加 Debug 可视化框架** — 给 ray tracer 加一组 keyword-driven 调试模式, 方便定位光照伪影。

## Changes

### Alpha pipeline 统一为 straight alpha
- 新 shader `Hidden/RainRust/Unpremultiply` + `RainRustUnpremultiplyPass`, 在 `DrawObjects` 之后 blit 一张 RT 把 `mainRt` 改写为 straight (`rgb = lightColor`, `a = 覆盖率 mask`), 下游全部按 straight 假设处理。
- `RayTracing.shader`:
  - early-exit: `return color.rgb` (去掉 `/a`)
  - ray-march: `return color.rgb * attenuation` (保持)
  - 命中判定: `color.a > _LightHitThreshold`
- `_LightHitThreshold` 暴露为 `RainRustVolume` 参数 (默认 `0.1`, 与 sprite shader `clip(a-0.1)` 对齐)。
- `JfaSeedInit.shader` 种子判定阈值从 `> 0.001` 收紧为 `> 0` (新语义下 alpha 直接即 mask)。

### Debug 可视化
- `RainRustVolume`: 新 `debugMode` 枚举 (None/Rand/SampleDir/ColorAlpha/EarlyExit/RayTermStep/HitFraction/Sdf/PixelInspector/GTRBreakdown) + `debugPixelUV`。
- `RayTracing.shader`: 加 `multi_compile_local _ DEBUG_*` 关键字, 命中任一 keyword 直接走调试输出 (绕开正常 ray tracing 路径)。
  - **PixelInspector**: 把指定像素的全部 ray 数据按 9 条横向 band 铺满屏幕 (hit/miss、命中色、贡献、share、used steps、GTR atten、ray dir、最终色、命中 UV)。
  - **GTRBreakdown**: 7 条 band 展示 GTR 输入参数诊断。
- `RainRustComposition.shader` + `RainRustRenderingPass`: 新增 `RAINRUST_DEBUG_OVERRIDE` keyword, 调试模式下 composition 直接输出 `lightingRt`, 绕过 receiver mask / blend。

### 杂项
- 两个 URP renderer asset (`urp_rendererData_default.asset`, `urp_rendererData_2d_default.asset`) 加 `unpremultiplyShader` GUID 引用。
- `DemoScene_02/volum Profile.asset` 同步新字段 + 调了一些 noise 参数。
- `Crt.mat` 微调。

## Test plan
- [ ] 启动游戏, 确认正常光照仍然渲染正确 (注意: 因为去掉了 cn.a 衰减, 整体亮度可能略高于改前, 必要时调 `lightIntensity`)。
- [ ] 切换 `RainRustVolume.debugMode` 验证每个调试模式输出符合预期。
- [ ] PixelInspector 模式下移动 `debugPixelUV`, 确认 9 条 band 数据随像素变化。
- [ ] `LightHitThreshold` 拉到 0 与 1 极值, 确认早退/光行走分支切换。

## 已知遗留 (本 PR 不处理)
- `receiverRt` 仍是 premultiplied, `RainRustComposition.shader` `lerp(bg, rcv.rgb, rcv.a)` 在透明 receiver 处仍存在 double-multiply。
- 边缘 bilinear 抖动 (用户明确 defer: "先只考虑修复 alpha 定义不一致, 不管抖动")。