### PR TITLE
Fix missing LFS scene object

### DIFF
--- a/Assets/GameMain/Scenes/Build/GameEntry.unity
+++ b/Assets/GameMain/Scenes/Build/GameEntry.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cafaa6deffdc33f87f02b43dae915dec12caaa3e2a6aec504e57959911a9c94
-size 16194
+oid sha256:ce7cbc2c320f5898d3f2ab9bbc0b492af278314e867ce9e8c80a9c233b237e8d
+size 14228

--- a/Assets/Prefabs/RunTime/System/[GameCore].prefab
+++ b/Assets/Prefabs/RunTime/System/[GameCore].prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff31b20b05ab30cbf7867feb173c77a28583e9ae2df9b9665ef82c39168fe085
-size 61873
+oid sha256:9c9df867cdea78342b5c1da14e688f4151e20f61235ae644be445bab2ef52660
+size 61846


### PR DESCRIPTION
## Summary
- update GameEntry scene LFS pointer to the newly uploaded object
- update GameCore prefab reference alongside the scene change

## Why
CI was failing during `git lfs pull` because `Assets/GameMain/Scenes/Build/GameEntry.unity` pointed at a missing LFS object (404). The replacement object has been uploaded to the configured LFS remote.

## Validation
- confirmed `git lfs push` uploaded the new GameEntry object
- branch push uploaded LFS objects successfully